### PR TITLE
modifications in accordance with eu_legal

### DIFF
--- a/advancedeucompliance.php
+++ b/advancedeucompliance.php
@@ -52,6 +52,9 @@ class Advancedeucompliance extends Module
     const LEGAL_ENVIRONMENTAL 	= 'LEGAL_ENVIRONMENTAL';
     const LEGAL_SHIP_PAY 		= 'LEGAL_SHIP_PAY';
 
+    /* Configuration const */
+    const MIN_WEIGHT_FOR_LABEL  = 1;
+
     public function __construct(Core_Foundation_Database_EntityManager $entity_manager,
                                 Core_Foundation_FileSystem_FileSystem $fs,
                                 Core_Business_Email_EmailLister $email)
@@ -87,11 +90,14 @@ class Advancedeucompliance extends Module
     {
         return parent::install() &&
                $this->loadTables() &&
+			   $this->installHooks() &&
                $this->registerHook('header') &&
                $this->registerHook('displayProductPriceBlock') &&
                $this->registerHook('overrideTOSDisplay') &&
                $this->registerHook('actionEmailAddAfterContent') &&
                $this->registerHook('advancedPaymentOptions') &&
+			   $this->registerHook('displayAfterShoppingCartBlock') &&
+			   $this->registerHook('displayBeforeShoppingCartBlock') &&
                $this->createConfig();
     }
 
@@ -102,22 +108,68 @@ class Advancedeucompliance extends Module
                $this->unloadTables();
     }
 
+	public function installHooks()
+	{
+		$hooks = array(
+			'displayBeforeShoppingCartBlock' => array(
+				'name' => 'display before Shopping cart block',
+				'templates' => array()
+			),
+			'displayAfterShoppingCartBlock' => array(
+				'name' => 'display after Shopping cart block',
+				'templates' => array()
+			)
+		);
+
+		$return = true;
+
+		foreach ($hooks as $hook_name => $hook)
+		{
+
+			if (Hook::getIdByName($hook_name))
+				continue;
+
+			$new_hook = new Hook();
+			$new_hook->name = $hook_name;
+			$new_hook->title = $hook['name'];
+			$new_hook->position = true;
+			$new_hook->live_edit = false;
+
+			if (!$new_hook->add())
+			{
+				$return &= false;
+				$this->_errors[] = $this->l('Could not install new hook').': '.$hook_name;
+			}
+
+		}
+
+		return $return;
+	}
+
     public function createConfig()
     {
         $delivery_time_available_values = array();
         $delivery_time_oos_values = array();
+		$shopping_cart_text_before = array();
+		$shopping_cart_text_after = array();
+
         $langs_repository = $this->entity_manager->getRepository('Language');
         $langs = $langs_repository->findAll();
 
         foreach ($langs as $lang) {
             $delivery_time_available_values[(int)$lang->id] = $this->l('Delivery: 1 to 3 weeks');
             $delivery_time_oos_values[(int)$lang->id] = $this->l('Delivery: 3 to 6 weeks');
+			$shopping_cart_text_before[(int)$lang->id] = '';
+			$shopping_cart_text_after[(int)$lang->id] = '';
         }
 
-        $this->processAeucFeatTellAFriend(false);
-        $this->processAeucFeatReorder(false);
+        $this->processAeucFeatTellAFriend(true);
+
+        $this->processAeucFeatReorder(true);
+
         $this->processAeucFeatAdvPaymentApi(false);
         $this->processAeucLabelRevocationTOS(false);
+		$this->processAeucLabelRevocationVP(true);
         $this->processAeucLabelSpecificPrice(true);
         $this->processAeucLabelTaxIncExc(true);
         $this->processAeucLabelShippingIncExc(false);
@@ -133,8 +185,11 @@ class Advancedeucompliance extends Module
                Configuration::updateValue('AEUC_LABEL_TAX_INC_EXC', true) &&
                Configuration::updateValue('AEUC_LABEL_WEIGHT', true) &&
                Configuration::updateValue('AEUC_LABEL_REVOCATION_TOS', false) &&
+			   Configuration::updateValue('AEUC_LABEL_REVOCATION_VP', true) &&
                Configuration::updateValue('AEUC_LABEL_SHIPPING_INC_EXC', false) &&
-               Configuration::updateValue('AEUC_LABEL_COMBINATION_FROM', true);
+               Configuration::updateValue('AEUC_LABEL_COMBINATION_FROM', true) &&
+			   Configuration::updateValue('AEUC_SHOPPING_CART_TEXT_BEFORE', $shopping_cart_text_before) &&
+			   Configuration::updateValue('AEUC_SHOPPING_CART_TEXT_AFTER', $shopping_cart_text_after);
     }
 
     public function unloadTables()
@@ -209,9 +264,34 @@ class Advancedeucompliance extends Module
                Configuration::deleteByName('AEUC_LABEL_TAX_INC_EXC') &&
                Configuration::deleteByName('AEUC_LABEL_WEIGHT') &&
                Configuration::deleteByName('AEUC_LABEL_REVOCATION_TOS') &&
+			   Configuration::deleteByName('AEUC_LABEL_REVOCATION_VP') &&
                Configuration::deleteByName('AEUC_LABEL_SHIPPING_INC_EXC') &&
-               Configuration::deleteByName('AEUC_LABEL_COMBINATION_FROM');
+               Configuration::deleteByName('AEUC_LABEL_COMBINATION_FROM') &&
+			   Configuration::deleteByName('AEUC_SHOPPING_CART_TEXT_BEFORE') &&
+			   Configuration::deleteByName('AEUC_SHOPPING_CART_TEXT_AFTER');
     }
+
+	/*
+		This method checks if cart has virtual products
+		It's better to add this method (as hasVirtualProduct) and add 'protected static $_hasVirtualProduct = array(); property
+		in Cart class in next version of prestashop.
+	*/
+
+	private function hasCartVirtualProduct(Cart $cart)
+	{
+		$products = $cart->getProducts();
+
+		if (!count($products))
+			return false;
+
+		foreach ($products as $product)
+		{
+			if ($product['is_virtual'])
+				return true;
+		}
+
+		return false;
+	}
 
     /* This hook is present to maintain backward compatibility */
     public function hookAdvancedPaymentOptions($param)
@@ -222,9 +302,11 @@ class Advancedeucompliance extends Module
                                                              'advancedeucompliance')));
         Media::addJsDef(array('aeuc_submit_err_str' => $this->l('Something went wrong. If the problem persists, please contact us.',
                                                                 'advancedeucompliance')));
+        Media::addJsDef(array('aeuc_no_pay_err_str' => $this->l('Select a payment option first.',
+                                                                'advancedeucompliance')));
         foreach ($legacyOptions as $module_name => $legacyOption) {
 
-            if (is_null($legacyOption) || $legacyOption === false) {
+            if (!$legacyOption) {
                 continue;
             }
 
@@ -309,8 +391,10 @@ class Advancedeucompliance extends Module
         $cms_role_repository = $this->entity_manager->getRepository('CMSRole');
         $cms_page_associated = $cms_role_repository->findOneByName(Advancedeucompliance::LEGAL_REVOCATION);
 
+		/*
         if (!$has_tos_override_opt || !$cms_page_associated instanceof CMSRole || (int)$cms_page_associated->id_cms == 0)
             return false;
+		*/
 
         // Get IDs of CMS pages required
         $cms_conditions_id = (int)Configuration::get('PS_CONDITIONS_CMS_ID');
@@ -340,15 +424,47 @@ class Advancedeucompliance extends Module
         else
             $link_revocations .= '&content_only=1';
 
+		// Check if cart has virtual product
+		$has_virtual_product = (bool)Configuration::get('AEUC_LABEL_REVOCATION_VP') && $this->hasCartVirtualProduct($this->context->cart);
+
         $this->context->smarty->assign(array(
+										   'conditions' => $has_tos_override_opt,
                                            'checkedTOS' => $checkedTos,
                                            'link_conditions' => $link_conditions,
-                                           'link_revocations' => $link_revocations
+                                           'link_revocations' => $link_revocations,
+										   'has_virtual_product' => $has_virtual_product
                                        ));
 
         $content = $this->context->smarty->fetch($this->local_path.'views/templates/hook/hookOverrideTOSDisplay.tpl');
         return $content;
     }
+
+	public function hookDisplayBeforeShoppingCartBlock($params)
+	{
+		if ($this->context->controller instanceof OrderOpcController || property_exists($this->context->controller, 'step') && $this->context->controller->step == 3)
+		{
+			$cart_text = Configuration::get('AEUC_SHOPPING_CART_TEXT_BEFORE', $this->context->language->id);
+
+			if ($cart_text)
+			{
+				$this->context->smarty->assign('cart_text', $cart_text);
+
+				return $this->display(__FILE__, 'displayShoppingCartBeforeBlock.tpl');
+			}
+		}
+	}
+
+	public function hookDisplayAfterShoppingCartBlock($params)
+	{
+		$cart_text = Configuration::get('AEUC_SHOPPING_CART_TEXT_AFTER', Context::getContext()->language->id);
+
+		if ($cart_text)
+		{
+			$this->context->smarty->assign('cart_text', $cart_text);
+
+			return $this->display(__FILE__, 'displayShoppingCartAfterBlock.tpl');
+		}
+	}
 
     public function hookDisplayProductPriceBlock($param)
     {
@@ -371,9 +487,25 @@ class Advancedeucompliance extends Module
         /* Handle Product Combinations label */
         if ($param['type'] == 'before_price' && (bool)Configuration::get('AEUC_LABEL_SPECIFIC_PRICE') === true) {
             if ($product->hasAttributes()) {
-                $smartyVars['before_price'] = array();
-                $smartyVars['before_price']['from_str_i18n'] = $this->l('From', 'advancedeucompliance');
-                return $this->dumpHookDisplayProductPriceBlock($smartyVars);
+                $need_display = false;
+                $combinations = $product->getAttributeCombinations($this->context->language->id);
+                if ($combinations && is_array($combinations)) {
+                    foreach ($combinations as $combination) {
+                        if ((float)$combination['price'] > 0) {
+                            $need_display = true;
+                            break;
+                        }
+                    }
+
+                    unset($combinations);
+
+                    if ($need_display) {
+                        $smartyVars['before_price'] = array();
+                        $smartyVars['before_price']['from_str_i18n'] = $this->l('From', 'advancedeucompliance');
+                        return $this->dumpHookDisplayProductPriceBlock($smartyVars);
+                    }
+                }
+                return;
             }
         }
 
@@ -422,7 +554,6 @@ class Advancedeucompliance extends Module
                         $smartyVars['ship']['link_ship_pay'] = $link_ship_pay;
                         $smartyVars['ship']['ship_str_i18n'] = $this->l('Shipping Excluded', 'advancedeucompliance');
                         $smartyVars['ship']['js_ship_fancybx'] = '<script type="text/javascript">
->>>>>>> 0072aafdb68a2aecfdeccf336b98a6098827f168
 																	$(document).ready(function(){
 																		if (!!$.prototype.fancybox)
 																			$("a.iframe").fancybox({
@@ -442,7 +573,7 @@ class Advancedeucompliance extends Module
         if ($param['type'] == 'weight' && (bool)Configuration::get('PS_DISPLAY_PRODUCT_WEIGHT') === true &&
             isset($param['hook_origin']) && $param['hook_origin'] == 'product_sheet'
         ) {
-            if ((int)$product->weight) {
+            if ((float)$product->weight && (float)$product->weight > (float)Advancedeucompliance::MIN_WEIGHT_FOR_LABEL) {
                 $smartyVars['weight'] = array();
                 $rounded_weight = round((float)$product->weight, Configuration::get('PS_PRODUCT_WEIGHT_PRECISION'));
                 $smartyVars['weight']['rounded_weight_str_i18n'] =
@@ -550,11 +681,23 @@ class Advancedeucompliance extends Module
                 $id_lang = (int)$exploded[$count - 1];
                 $i10n_inputs_received['AEUC_LABEL_DELIVERY_TIME_OOS'][$id_lang] = $received_values[$key_received];
             }
-
+			if (strripos($key_received, 'AEUC_SHOPPING_CART_TEXT_BEFORE') !== false) {
+				$exploded = explode('_', $key_received);
+				$count = count($exploded);
+				$id_lang = (int)$exploded[$count - 1];
+				$i10n_inputs_received['AEUC_SHOPPING_CART_TEXT_BEFORE'][$id_lang] = $received_values[$key_received];
+			}
+			if (strripos($key_received, 'AEUC_SHOPPING_CART_TEXT_AFTER') !== false) {
+				$exploded = explode('_', $key_received);
+				$count = count($exploded);
+				$id_lang = (int)$exploded[$count - 1];
+				$i10n_inputs_received['AEUC_SHOPPING_CART_TEXT_AFTER'][$id_lang] = $received_values[$key_received];
+			}
         }
 
         if (count($i10n_inputs_received) > 0) {
             $this->processAeucLabelDeliveryTime($i10n_inputs_received);
+			$this->processAeucShoppingCartText($i10n_inputs_received);
             $has_processed_something = true;
         }
 
@@ -578,6 +721,16 @@ class Advancedeucompliance extends Module
             Configuration::updateValue('AEUC_LABEL_DELIVERY_TIME_OOS', $i10n_inputs['AEUC_LABEL_DELIVERY_TIME_OOS']);
         }
     }
+
+	protected function processAeucShoppingCartText(array $i10n_inputs)
+	{
+		if (isset($i10n_inputs['AEUC_SHOPPING_CART_TEXT_BEFORE'])) {
+			Configuration::updateValue('AEUC_SHOPPING_CART_TEXT_BEFORE', $i10n_inputs['AEUC_SHOPPING_CART_TEXT_BEFORE']);
+		}
+		if (isset($i10n_inputs['AEUC_SHOPPING_CART_TEXT_AFTER'])) {
+			Configuration::updateValue('AEUC_SHOPPING_CART_TEXT_AFTER', $i10n_inputs['AEUC_SHOPPING_CART_TEXT_AFTER']);
+		}
+	}
 
     protected function processAeucLabelCombinationFrom($is_option_active)
     {
@@ -637,6 +790,15 @@ class Advancedeucompliance extends Module
             Configuration::updateValue('AEUC_LABEL_REVOCATION_TOS', false);
         }
     }
+
+	protected function processAeucLabelRevocationVP($is_option_active)
+	{
+		if ((bool)$is_option_active) {
+			Configuration::updateValue('AEUC_LABEL_REVOCATION_VP', true);
+		} else {
+			Configuration::updateValue('AEUC_LABEL_REVOCATION_VP', false);
+		}
+	}
 
     protected function processAeucLabelShippingIncExc($is_option_active)
     {
@@ -879,6 +1041,26 @@ class Advancedeucompliance extends Module
                                     )
                                 ),
                             ),
+							array(
+								'type' => 'switch',
+								'label' => $this->l('Revocation of vitual products', 'advancedeucompliance'),
+								'name' => 'AEUC_LABEL_REVOCATION_VP',
+								'is_bool' => true,
+								'desc' => $this->l('Include checkbox of agreement if cart has virtual product. ', 'advancedeucompliance'),
+								'disable' => true,
+								'values' => array(
+									array(
+										'id' => 'active_on',
+										'value' => true,
+										'label' => $this->l('Enabled', 'advancedeucompliance')
+									),
+									array(
+										'id' => 'active_off',
+										'value' => false,
+										'label' => $this->l('Disabled', 'advancedeucompliance')
+									)
+								),
+							),
                             array(
                                 'type' => 'switch',
                                 'label' => $this->l('\'From\' price label (when combinations)'),
@@ -902,6 +1084,21 @@ class Advancedeucompliance extends Module
                                     )
                                 ),
                             ),
+							array(
+								'type' => 'textarea',
+								'lang' => true,
+								'label' => $this->l('Shopping cart text 1', 'advancedeucompliance'),
+								'name' => 'AEUC_SHOPPING_CART_TEXT_BEFORE',
+								'desc' => $this->l('This text is displayed before the shopping cart block.', 'advancedeucompliance'),
+							),
+							array(
+								'type' => 'textarea',
+								'lang' => true,
+								'label' => $this->l('Shopping cart text 2', 'advancedeucompliance'),
+								'name' => 'AEUC_SHOPPING_CART_TEXT_AFTER',
+								'desc' => $this->l('This text is displayed after the shopping cart block.', 'advancedeucompliance'),
+							),
+
         ),
                                      'submit' => array(
                                          'title' => $this->l('Save', 'advancedeucompliance'),
@@ -917,12 +1114,17 @@ class Advancedeucompliance extends Module
     {
         $delivery_time_available_values = array();
         $delivery_time_oos_values = array();
+		$shopping_cart_text_before_values = array();
+		$shopping_cart_text_after_values = array();
+
         $langs = Language::getLanguages(false, false);
 
         foreach ($langs as $lang) {
             $tmp_id_lang = (int)$lang['id_lang'];
             $delivery_time_available_values[$tmp_id_lang] = Configuration::get('AEUC_LABEL_DELIVERY_TIME_AVAILABLE', $tmp_id_lang);
             $delivery_time_oos_values[$tmp_id_lang] = Configuration::get('AEUC_LABEL_DELIVERY_TIME_OOS', $tmp_id_lang);
+			$shopping_cart_text_before_values[$tmp_id_lang] = Configuration::get('AEUC_SHOPPING_CART_TEXT_BEFORE', $tmp_id_lang);
+			$shopping_cart_text_after_values[$tmp_id_lang] = Configuration::get('AEUC_SHOPPING_CART_TEXT_AFTER', $tmp_id_lang);
         }
 
         return array(
@@ -932,8 +1134,11 @@ class Advancedeucompliance extends Module
             'AEUC_LABEL_TAX_INC_EXC' => Configuration::get('AEUC_LABEL_TAX_INC_EXC'),
             'AEUC_LABEL_WEIGHT' => Configuration::get('AEUC_LABEL_WEIGHT'),
             'AEUC_LABEL_REVOCATION_TOS' => Configuration::get('AEUC_LABEL_REVOCATION_TOS'),
+			'AEUC_LABEL_REVOCATION_VP' => Configuration::get('AEUC_LABEL_REVOCATION_VP'),
             'AEUC_LABEL_SHIPPING_INC_EXC' => Configuration::get('AEUC_LABEL_SHIPPING_INC_EXC'),
-            'AEUC_LABEL_COMBINATION_FROM' => Configuration::get('AEUC_LABEL_COMBINATION_FROM')
+            'AEUC_LABEL_COMBINATION_FROM' => Configuration::get('AEUC_LABEL_COMBINATION_FROM'),
+			'AEUC_SHOPPING_CART_TEXT_BEFORE' => $shopping_cart_text_before_values,
+			'AEUC_SHOPPING_CART_TEXT_AFTER' => $shopping_cart_text_after_values,
         );
     }
 

--- a/advancedeucompliance.php
+++ b/advancedeucompliance.php
@@ -335,7 +335,7 @@ class Advancedeucompliance extends Module
             $tpl_name = (string)$tpl_name_exploded[0];
 
         $id_lang = (int)$param['id_lang'];
-        $mail_id = AeucEmailEntity::getMailIdFromTplFilename($tpl_name);
+        $mail_id = AeucEmailEntity::getMailIdFromTplFilename($tpl_name.'.html');
 
         if (!isset($mail_id['id_mail']))
             return;

--- a/views/templates/hook/displayShoppingCartAfterBlock.tpl
+++ b/views/templates/hook/displayShoppingCartAfterBlock.tpl
@@ -1,0 +1,25 @@
+{**
+ * 2007-2015 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author 	PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2015 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ *}
+<p>{$cart_text|escape:'htmlall'}</p>

--- a/views/templates/hook/displayShoppingCartBeforeBlock.tpl
+++ b/views/templates/hook/displayShoppingCartBeforeBlock.tpl
@@ -1,0 +1,25 @@
+{**
+ * 2007-2015 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author 	PrestaShop SA <contact@prestashop.com>
+ *  @copyright  2007-2015 PrestaShop SA
+ *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ *}
+<p>{$cart_text|escape:'htmlall'}</p>

--- a/views/templates/hook/hookOverrideTOSDisplay.tpl
+++ b/views/templates/hook/hookOverrideTOSDisplay.tpl
@@ -25,13 +25,28 @@
 
 <div class="row">
     <div class="col-xs-12 col-md-12">
-        <h2>{l s='Terms and Conditions' mod='advancedeucompliance'}</h2>
+        {*<h2>{l s='Terms and Conditions' mod='advancedeucompliance'}</h2>*}
         <div class="tnc_box">
             <p class="checkbox">
+                {if isset($conditions) && $conditions}
+                    <input type="checkbox" name="cgv" id="cgv" value="1" {if $checkedTOS}checked="checked"{/if}/>
+                {else}
+                    <input type="checkbox" name="cgv" id="cgv" value="1" checked style="display:none;"/>
+                {/if}
+                {if isset($link_conditions) && $link_conditions}
+                    <label for="cgv">{l s='I agree to the' mod='advancedeucompliance'}</label> <a href="{$link_conditions|escape:'html':'UTF-8'}" class="iframe" rel="nofollow">{l s='terms of service'  mod='advancedeucompliance'}</a>
+                {/if}
+                {if isset($link_revocations) && $link_revocations}
+                    <label for="cgv">{l s='and'  mod='advancedeucompliance'}</label> <a href="{$link_revocations|escape:'html':'UTF-8'}" class="iframe" rel="nofollow">{l s='terms of revocation' mod='advancedeucompliance'}</a>
+                {/if}
+                <label for="cgv">{l s='adhire to them unconditionally.'  mod='advancedeucompliance'}</label>
+
+                {*
                 <input type="checkbox" name="cgv" id="cgv" value="1" {if $checkedTOS}checked="checked"{/if} />
                 <label for="cgv">{l s='I agree to the terms of service and the terms of revocation and will adhere to them unconditionally.' mod='advancedeucompliance'}</label>
                 <a href="{$link_conditions|escape:'html':'UTF-8'}" class="iframe" rel="nofollow">{l s='(Read the Terms of Service)' mod='advancedeucompliance'}</a>
                 <a href="{$link_revocations|escape:'html':'UTF-8'}" class="iframe" rel="nofollow">{l s='(Read the Terms of Revocation)' mod='advancedeucompliance'}</a>
+                *}
             </p>
             <script type="text/javascript">
                 $(document).ready(function(){
@@ -44,5 +59,54 @@
                 })
             </script>
         </div>
+        {if $has_virtual_product}
+        <div class="tnc_box">
+            <p class="carrier_title">{l s='Revocation of virtual products' mod='advancedeucompliance'}</p>
+            <p class="checkbox">
+                <input type="checkbox" name="revocation_vp_terms_agreed" id="revocation_vp_terms_agreed" value="1"/>
+                <label for="revocation_vp_terms_agreed">{l s='I agree that the digital products in my cart can not be returned or refunded due to the nature of such products.' mod='advancedeucompliance'}</label>
+            </p>
+        </div>
+        <script type="text/javascript">
+            /*
+            *  we have to add new function on 'click' on #confirmOrder in themes/default-bootstrap/js/advanced-payment-api.js
+            */
+            $(document).ready(function() {
+                // unbind
+                $('#confirmOrder').unbind('click');
+
+                //new one
+                var has_virtual_product = true;
+                var handler = new PaymentOptionHandler();
+                $('#confirmOrder').on('click', function(event){
+                    /* Avoid any further action */
+                    event.preventDefault();
+                    event.stopPropagation();
+
+                    if (!handler.checkTOS())
+                    {
+                        alert('Please check TOS box first !')
+                        return;
+                    }
+
+                    if (has_virtual_product &&  !$('#revocation_vp_terms_agreed').is(':checked'))
+                    {
+                        alert('Please check \'Revocation of virtual products\' box first !')
+                        return;
+                    }
+
+                    var payment_details = handler.getSelectedPaymentOptionDetails();
+                    if (payment_details !== false && payment_details.action) {
+                        handler.submitPaymentOption(payment_details.action, payment_details.data);
+                    } else if (!payment_details.action && payment_details.has_form === true) {
+                        payment_details.form_to_submit.submit();
+                    } else {
+                        alert('An error occured please be sure you have properly selected your payment option!');
+                        return;
+                    }
+                });
+            });
+        </script>
+        {/if}
     </div>
 </div>


### PR DESCRIPTION
+ checkbox for virtual products added (we  use a local js to check the VP. still, this script need to be outtakes and implemented into the core. Please refer to our comments in the pull request.)
+ a switch button added in the modul's settings.
+ two text blocks in the cart (we added a hook DisplayBlockAfterShoppingCart inside the theme's tpl file)
+ we changed the checkbox' behaviour. when switched off, ToS and revocation links still remain.