### PR TITLE
Avoid unattended carriage return in price block

### DIFF
--- a/assets/css/aeuc_front.css
+++ b/assets/css/aeuc_front.css
@@ -56,3 +56,7 @@ div.aeuc_delivery_label {
     color: #554f58;
     font-size: 12px;
 }
+
+.content_price > span {
+	display:inline-block;
+}


### PR DESCRIPTION
Add a small style definition for price block in order to remove carriage return inside a label.

With this change ...
![capture du 2015-06-03 14 41 17](https://cloud.githubusercontent.com/assets/6768917/7960250/5354dfec-09ff-11e5-8c02-c1b6c1935836.png)
... will become ...
![capture du 2015-06-03 14 42 06](https://cloud.githubusercontent.com/assets/6768917/7960254/58139334-09ff-11e5-9b6e-1fb95735f6b7.png)
