### PR TITLE
[*] MO : advancedeucompliance MIN_WEIGHT_FOR_LABEL adjusted

### DIFF
--- a/advancedeucompliance.php
+++ b/advancedeucompliance.php
@@ -53,7 +53,7 @@ class Advancedeucompliance extends Module
     const LEGAL_SHIP_PAY 		= 'LEGAL_SHIP_PAY';
 
     /* Configuration const */
-    const MIN_WEIGHT_FOR_LABEL  = 1;
+    const MIN_WEIGHT_FOR_LABEL  = 0.001;
 
     public function __construct(Core_Foundation_Database_EntityManager $entity_manager,
                                 Core_Foundation_FileSystem_FileSystem $fs,
@@ -610,7 +610,7 @@ class Advancedeucompliance extends Module
         if ($param['type'] == 'weight' && (bool)Configuration::get('PS_DISPLAY_PRODUCT_WEIGHT') === true &&
             isset($param['hook_origin']) && $param['hook_origin'] == 'product_sheet'
         ) {
-            if ((float)$product->weight && (float)$product->weight > (float)Advancedeucompliance::MIN_WEIGHT_FOR_LABEL) {
+            if ((float)$product->weight && (float)$product->weight >= (float)Advancedeucompliance::MIN_WEIGHT_FOR_LABEL) {
                 $smartyVars['weight'] = array();
                 $rounded_weight = round((float)$product->weight, Configuration::get('PS_PRODUCT_WEIGHT_PRECISION'));
                 $smartyVars['weight']['rounded_weight_str_i18n'] =


### PR DESCRIPTION
Adjusted MIN_WEIGHT_FOR_LABEL to show weight even if product is just 1 gram.

PS_PRODUCT_WEIGHT_PRECISION needs adjusting too. But I am unsure if this is a general necessity or only for advancedeucompliance users.