### PR TITLE
Bug: wrong CSS voids some other CSS

### DIFF
--- a/views/css/aeuc_front.css
+++ b/views/css/aeuc_front.css
@@ -53,6 +53,10 @@ div.aeuc_shipping_label {
 	display:inline-block;
 }
 
+span.unvisible {
+	display: none; 
+}
+
 p.payment_selected > a.payment_module_adv {
     border: 1px solid #55c65e;
     border-radius: 4px;


### PR DESCRIPTION
Code for span.unvisible makes unvisible spans with class .unvisible visible. So we have to restrict the effect of the css code by re-assigning code for unvisible spans again.