### PR TITLE
MO : Bugfix fo_aeuc_tnc.js

### DIFF
--- a/views/js/fo_aeuc_tnc.js
+++ b/views/js/fo_aeuc_tnc.js
@@ -35,7 +35,7 @@ $(document).ready(function(){
         });
     }
 
-    $('button[name="processCarrier"]').click(function(event){
+    $('button[name="processPayment"]').click(function(event){
         /* Avoid any further action */
         event.preventDefault();
         event.stopPropagation();


### PR DESCRIPTION
<!-- Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows with the necessary information:-->

| Questions | Answers |
| --- | --- |
| Branch? | 1.6.1.x |
| Description? | This bug only appears in standard 5-step-checkout when ordering virtual products. Error message of not having checked the VP conditions is displayed before check is possible in next step. Result: Order process is stopped! |
| Type? | bug fix |
| Category? | MO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? |  |
| How to test? |  |

<!-- Click the form's "Preview button" to make sure the table is functional in GitHub. Thank you! -->
