### PR TITLE
MO : Bugfix  hookDisplayProductPriceBlock.tpl

### DIFF
--- a/views/templates/hook/hookDisplayProductPriceBlock.tpl
+++ b/views/templates/hook/hookDisplayProductPriceBlock.tpl
@@ -22,7 +22,7 @@
  *  @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  *  International Registered Trademark & Property of PrestaShop SA
  *}
-
+{nocache}
 {if isset($smartyVars)}
     {* "From" Price Hook templating *}
     {if isset($smartyVars.before_price) && isset($smartyVars.before_price.from_str_i18n)}
@@ -73,3 +73,4 @@
         </div>
     {/if}
 {/if}
+{/nocache}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | 1.6.1.x
| Description?  | This hook with different parameters causes weird cache phenomena like e.g. replacing _from_-price,  _weight_ or _"tax incl./excl."_ with delivery time, so that instead of the correct display of different information up to 3 times the delivery time or "tax incl" will be repeated. This usually happens after placing an order. As _blockbestsellers_ uses this hook too, it shares the problem.
| Type?         | bug fix 
| Category?     |  MO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | 


